### PR TITLE
Fix carrier info in order fulfillment feed

### DIFF
--- a/src/amazon/schemas.ts
+++ b/src/amazon/schemas.ts
@@ -18,7 +18,6 @@ export var FlatFileOrderFulfillmentFeedOptions: CSV.Options = {
     defaults: {
         'ship-date': moment().format('YYYY-MM-DD'),
         'carrier-code': 'DHL',
-        'carrier-name': 'DHL',
         'ship-method': 'DHL Paket'
     },
     firstLine: null,


### PR DESCRIPTION
`carrier-name` should only be specified if the value for `carrier-code` is "Anderer" (other), according to: https://images-na.ssl-images-amazon.com/images/G/01/rainier/help/ff/release_1_9/Flat.File.ShippingConfirm.de.xls
